### PR TITLE
Add B-B-B to AVS result mapping

### DIFF
--- a/app/decorators/controllers/solidus_paypal_braintree/spree/checkout_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_paypal_braintree/spree/checkout_controller_decorator.rb
@@ -1,10 +1,12 @@
 module SolidusPaypalBraintree
-  module CheckoutControllerDecorator
+  module Spree
+    module CheckoutControllerDecorator
 
-    def self.prepended(base)
-      base.helper ::SolidusPaypalBraintree::BraintreeCheckoutHelper
+      def self.prepended(base)
+        base.helper ::SolidusPaypalBraintree::BraintreeCheckoutHelper
+      end
+
+      ::Spree::CheckoutController.prepend(self)
     end
-
-    ::Spree::CheckoutController.prepend(self)
   end
 end

--- a/app/models/solidus_paypal_braintree/avs_result.rb
+++ b/app/models/solidus_paypal_braintree/avs_result.rb
@@ -41,6 +41,7 @@ module SolidusPaypalBraintree
         'I' => 'I',
         'A' => 'I'
       },
+      'B' => { 'B' => 'B' },
       nil => { nil => nil }
     }.freeze
 

--- a/lib/solidus_paypal_braintree/version.rb
+++ b/lib/solidus_paypal_braintree/version.rb
@@ -1,3 +1,3 @@
 module SolidusPaypalBraintree
-  VERSION = '1.0.0.paragon'
+  VERSION = '1.0.0.paragon2'
 end

--- a/spec/models/solidus_paypal_braintree/avs_result_spec.rb
+++ b/spec/models/solidus_paypal_braintree/avs_result_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 RSpec.describe SolidusPaypalBraintree::AVSResult do
   describe 'AVS response message' do
-    subject { described_class.build(transaction).to_hash['message'] }
+    subject { avs_result.to_hash['message'] }
+
+    let(:avs_result) { described_class.build(transaction) }
 
     context 'with avs_error_response_code' do
       let(:transaction) do
@@ -179,6 +181,19 @@ RSpec.describe SolidusPaypalBraintree::AVSResult do
         let(:codes) { %w(N M) }
         it { is_expected.to eq 'Street address does not match, but 5-digit postal code matches.' }
         it { expect(described_class.build(transaction).to_hash).to include('street_match' => 'N', 'postal_match' => 'M') }
+      end
+
+      context 'when street address result is B and postal code result is B' do
+        let(:codes) { %w(B B) }
+
+        it do
+          expect(avs_result).to have_attributes(
+            'code' => 'B',
+            'message' => 'Street address matches, but postal code not verified.',
+            'street_match' => 'B',
+            'postal_match' => 'B'
+          )
+        end
       end
 
       context 'street address response code is nil' do


### PR DESCRIPTION
Based on https://github.com/activemerchant/active_merchant/blob/abc50bf93aff4dac8368119fd81280fc7f1e07d4/lib/active_merchant/billing/gateways/braintree_blue.rb#L417